### PR TITLE
Modifying UsersImporter to output failed imports to csv file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,3 @@ DEPENDENCIES
   sinatra-contrib
   sqlite3
   tux
-
-BUNDLED WITH
-   1.10.6

--- a/lib/users_importer.rb
+++ b/lib/users_importer.rb
@@ -8,6 +8,7 @@ class UsersImporter
     field_names = ['first_name', 'last_name', 'email', 'password', 'latitude', 'longitude']
     puts "Importing users from '#{@filename}'"
     failure_count = 0
+    fails = []
     User.transaction do
       File.open(@filename).each do |line|
         data = line.chomp.split(',')
@@ -18,13 +19,28 @@ class UsersImporter
         rescue ActiveRecord::UnknownAttributeError
           failure_count += 1
           print '!'
+          fails.push(data)
         ensure
           STDOUT.flush
         end
       end
     end
-    failures = failure_count > 0 ? "(failed to create #{failure_count} user records)" : ''
-    puts "\nDONE #{failures}\n\n"
+    #failures = failure_count > 0 ? "(failed to create #{failure_count} user records)" : ''
+    #puts "\nDONE #{failures}\n\n"
+    if failure_count > 0
+      error_file = "#{@filename}_errors.csv"
+      File.open(error_file, 'w') do |errors|
+        errors.puts field_names
+        errors.puts "\n"
+        fails.each do |fail|
+          errors.puts fail.join(',')
+          errror.puts "\n"
+        end
+      end
+      puts "#{failue_count} records were not created.  There were expored to #{error_file} for review"
+    else
+      puts "\nDONE\n importing #{@filename}"
+    end
   end
 
 end


### PR DESCRIPTION
Pardon the intrusion but saw your project and as a bibliophile and someone getting started in ruby it interested me so I watched it.  I expanded your UsersImporter, hopefully, to write any failed imports to an error file.
